### PR TITLE
Fix memory allocation and uninitialized variable

### DIFF
--- a/db_rw.c
+++ b/db_rw.c
@@ -35,7 +35,7 @@ void menu(){
 		printf("Accessing database...\n");
 
 		
-		int choice;
+               int choice = 0;
 		char read_buffer[1024];
 		char write_buffer[1024];
 		
@@ -65,7 +65,7 @@ void menu(){
 				printf("Type in the data you would like to write to the database: ");
 				scanf("%s", write_buffer);
 				data = encrypt(password, write_buffer);
-				write(file_descriptor, data, 1024);
+                               write(file_descriptor, data, strlen(data));
 				close(file_descriptor);
 				free(data);
 			}
@@ -103,7 +103,7 @@ int derive_key(const char *password){
 char * encrypt(const char *password, const char *data){
 	int key = derive_key(password);
 	int length = strlen(data);
-	char *encrypted_data = (char *)malloc(length * sizeof(char));
+       char *encrypted_data = (char *)malloc((length + 1) * sizeof(char));
 	int i;
 	for (i = 0; i < length; i++){
 		encrypted_data[i] = data[i] + key;
@@ -118,7 +118,7 @@ char * encrypt(const char *password, const char *data){
 char * decrypt(const char *password, const char *data){
 	int key = derive_key(password);
 	int length = strlen(data);
-	char *decrypted_data = (char *)malloc(length * sizeof(char));
+       char *decrypted_data = (char *)malloc((length + 1) * sizeof(char));
 	int i;
 	for (i = 0; i < length; i++){
 		decrypted_data[i] = data[i] - key;


### PR DESCRIPTION
## Summary
- initialise the `choice` variable in db menu
- fix write call to use actual data length
- allocate space for null terminator in encrypt/decrypt helpers

## Testing
- `make`
- `./db_read_write <<EOF
wrongpass
EOF`
- `./db_read_write <<EOF
password
3
EOF`
